### PR TITLE
Allow request body for DELETE http method

### DIFF
--- a/src/Request/Builder/RequestBuilder.php
+++ b/src/Request/Builder/RequestBuilder.php
@@ -285,6 +285,7 @@ class RequestBuilder
             case 'POST':
             case 'PUT':
             case 'PATCH':
+            case 'DELETE':
                 if (false === array_key_exists('Content-Type', $this->headers)) {
                     break;
                 }


### PR DESCRIPTION
Sometimes a delete operation might need some additional data beside filter parameters that should be sent as payload body.

HTTP RFC 7231 says `A payload within a DELETE request message has no defined semantics` ... but it is still allowed
