### PR TITLE
Resolve symfony 5.4+ / PHP 8.1+ deprecations

### DIFF
--- a/src/CurlInfo.php
+++ b/src/CurlInfo.php
@@ -39,11 +39,19 @@ class CurlInfo implements \ArrayAccess, \Countable, \IteratorAggregate
         $this->info = $info;
     }
 
+    /**
+     * @return \Traversable
+     */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->info);
     }
 
+    /**
+     * @return int
+     */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->info);
@@ -58,11 +66,19 @@ class CurlInfo implements \ArrayAccess, \Countable, \IteratorAggregate
         return $this->offsetGet($key);
     }
 
+    /**
+     * @return bool
+     */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return array_key_exists($offset, $this->info);
     }
 
+    /**
+     * @return mixed
+     */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if (false === $this->offsetExists($offset)) {
@@ -72,11 +88,19 @@ class CurlInfo implements \ArrayAccess, \Countable, \IteratorAggregate
         return $this->info[$offset];
     }
 
+    /**
+     * @return void
+     */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->info[$offset] = $value;
     }
 
+    /**
+     * @return void
+     */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         if (false === $this->offsetExists($offset)) {
@@ -214,5 +238,4 @@ class CurlInfo implements \ArrayAccess, \Countable, \IteratorAggregate
     {
         return $this->get(self::CURL_LOCAL_PORT);
     }
-
 }

--- a/src/Request/CurlRequest.php
+++ b/src/Request/CurlRequest.php
@@ -74,6 +74,9 @@ class CurlRequest implements RequestInterface
         return $this->request->getRequestTarget();
     }
 
+    /**
+     * @return static
+     */
     public function withRequestTarget($requestTarget)
     {
         $copy = clone $this;
@@ -87,6 +90,9 @@ class CurlRequest implements RequestInterface
         return $this->request->getMethod();
     }
 
+    /**
+     * @return static
+     */
     public function withMethod($method)
     {
         $copy = clone $this;
@@ -100,6 +106,9 @@ class CurlRequest implements RequestInterface
         return $this->request->getUri();
     }
 
+    /**
+     * @return static
+     */
     public function withUri(UriInterface $uri, $preserveHost = false)
     {
         $copy = clone $this;
@@ -113,6 +122,9 @@ class CurlRequest implements RequestInterface
         return $this->request->getProtocolVersion();
     }
 
+    /**
+     * @return static
+     */
     public function withProtocolVersion($version)
     {
         $copy = clone $this;
@@ -141,6 +153,9 @@ class CurlRequest implements RequestInterface
         return $this->request->getHeaderLine($name);
     }
 
+    /**
+     * @return static
+     */
     public function withHeader($name, $value)
     {
         $copy = clone $this;
@@ -149,6 +164,9 @@ class CurlRequest implements RequestInterface
         return $copy;
     }
 
+    /**
+     * @return static
+     */
     public function withAddedHeader($name, $value)
     {
         $copy = clone $this;
@@ -157,6 +175,9 @@ class CurlRequest implements RequestInterface
         return $copy;
     }
 
+    /**
+     * @return static
+     */
     public function withoutHeader($name)
     {
         $copy = clone $this;
@@ -170,6 +191,9 @@ class CurlRequest implements RequestInterface
         return $this->request->getBody();
     }
 
+    /**
+     * @return static
+     */
     public function withBody(StreamInterface $body)
     {
         $copy = clone $this;

--- a/src/Response/CurlResponse.php
+++ b/src/Response/CurlResponse.php
@@ -24,6 +24,9 @@ class CurlResponse implements ResponseInterface
         return $this->response->getProtocolVersion();
     }
 
+    /**
+     * @return static
+     */
     public function withProtocolVersion($version)
     {
         $copy = clone $this;
@@ -52,6 +55,9 @@ class CurlResponse implements ResponseInterface
         return $this->response->getHeaderLine($name);
     }
 
+    /**
+     * @return static
+     */
     public function withHeader($name, $value)
     {
         $copy = clone $this;
@@ -60,6 +66,9 @@ class CurlResponse implements ResponseInterface
         return $copy;
     }
 
+    /**
+     * @return static
+     */
     public function withAddedHeader($name, $value)
     {
         $copy = clone $this;
@@ -68,6 +77,9 @@ class CurlResponse implements ResponseInterface
         return $copy;
     }
 
+    /**
+     * @return static
+     */
     public function withoutHeader($name)
     {
         $copy = clone $this;
@@ -81,6 +93,9 @@ class CurlResponse implements ResponseInterface
         return $this->response->getBody();
     }
 
+    /**
+     * @return static
+     */
     public function withBody(StreamInterface $body)
     {
         $copy = clone $this;
@@ -94,6 +109,9 @@ class CurlResponse implements ResponseInterface
         return $this->response->getStatusCode();
     }
 
+    /**
+     * @return static
+     */
     public function withStatus($code, $reasonPhrase = '')
     {
         $copy = clone $this;


### PR DESCRIPTION
Prepare for PHP 8.1 deprecations - add return types in phpdoc and `#[\ReturnTypeWillChange]`

Symfony deprecation messages:
>   1x: Method "Psr\Http\Message\MessageInterface::withBody()" might add "static" as a native return type declaration in the future. Do the same in implementation "Http\Client\Curl\Request\CurlRequest" now to avoid errors or add an explicit @return annotation to suppress this message.

See also: https://wiki.php.net/rfc/internal_method_return_types